### PR TITLE
Refactor's Clang formatting - Following LLVM style guide + Makefile shortcuts & compiler controls

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,119 +1,21 @@
-# SPDX-License-Identifier: GPL-2.0
-#
-# clang-format configuration file. Intended for clang-format >= 11.
-#
-# For more information, see:
-#
-#   Documentation/dev-tools/clang-format.rst
-#   https://clang.llvm.org/docs/ClangFormat.html
-#   https://clang.llvm.org/docs/ClangFormatStyleOptions.html
-#
 ---
-BasedOnStyle: LLVM
-AccessModifierOffset: -4
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: true 
-AlignEscapedNewlines: Left
-AlignOperands: true
-AlignTrailingComments: false
-AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
-BinPackArguments: true
-BinPackParameters: true
-BraceWrapping:
-  AfterClass: false
-  AfterControlStatement: false
-  AfterEnum: false
-  AfterFunction: true
-  AfterNamespace: true
-  AfterObjCDeclaration: false
-  AfterStruct: false
-  AfterUnion: false
-  AfterExternBlock: false
-  BeforeCatch: false
-  BeforeElse: false
-  IndentBraces: false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Custom
-BreakBeforeInheritanceComma: false
-BreakBeforeTernaryOperators: false
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeComma
-BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: false
-ColumnLimit: 120 
-CommentPragmas: '^ IWYU pragma:'
-CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 4 
-ContinuationIndentWidth: 4 
-Cpp11BracedListStyle: false
-DerivePointerAlignment: false
-DisableFormat: false
-ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: false
 
-IncludeBlocks: Preserve
-IncludeCategories:
-  - Regex: '.*'
-    Priority: 1
-IncludeIsMainRegex: '(Test)?$'
-IndentCaseLabels: false
-IndentGotoLabels: false
-IndentPPDirectives: None
-IndentWidth: 4 
-IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd: ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBinPackProtocolList: Auto
-ObjCBlockIndentWidth: 4 
-ObjCSpaceAfterProperty: true
-ObjCSpaceBeforeProtocolList: true
+# clang-format documentation
+# http://clang.llvm.org/docs/ClangFormat.html
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 
-# Taken from git's rules
-PenaltyBreakAssignment: 10
-PenaltyBreakBeforeFirstCallParameter: 30
-PenaltyBreakComment: 10
-PenaltyBreakFirstLessLess: 0
-PenaltyBreakString: 10
-PenaltyExcessCharacter: 100
-PenaltyReturnTypeOnItsOwnLine: 60
+# Preexisting formats:
+# LLVM
+# Google
+# Chromium
+# Mozilla
+# WebKit
+# Microsoft
+# GNU
 
-PointerAlignment: Right
-ReflowComments: true 
-SortIncludes: true 
-SortUsingDeclarations: false
-SpaceAfterCStyleCast: false
-SpaceAfterTemplateKeyword: true
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeCtorInitializerColon: true
-SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatementsExceptForEachMacros
-SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
-SpacesInContainerLiterals: false
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard: Cpp03
-TabWidth: 4 
-UseTab: Always
+Language:        Cpp
+BasedOnStyle:   LLVM
+ColumnLimit:     120
+IndentWidth:     3
+...
+

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,46 @@ EXCLUDE_SRC_FROM_LIB+=$(foreach file, $(SRCDIR)/main,$(foreach cext,$(CEXTS),$(f
 # that are in the the include directory get exported
 TEMPLATE_FILES=$(INCDIR)/**/*.h $(INCDIR)/**/*.hpp
 
+USER_HEADERS=$(INCDIR)/screen/*.h $(INCDIR)/*.h $(INCDIR)/robot/*.h
+
+USER_SRC=$(SRCDIR)/**/*.cpp $(SRCDIR)/*.cpp
+
 .DEFAULT_GOAL=quick
 
 ################################################################################
 ################################################################################
 ########## Nothing below this line should be edited by typical users ###########
 -include ./common.mk
+
+# @...||: is a hack to prevent make from failing if the command outputs a non-fail result -> This is because we recieve is a directory error
+format-all: format-src format-includes
+
+format-src:
+	@clang-format -i $(USER_SRC) --style file ||:
+
+format-includes:
+	@clang-format -i $(USER_HEADERS) --style file ||:
+
+
+lint-all: lint-src lint-includes
+
+lint-src:
+	@clang-tidy $(USER_SRC) -checks=-cppcoreguidelines-* --format-style=file ||:
+	@echo -e "\033[0;32mNon user-code errors can be ignored.\033[0m They are \033[1;33mnot relevant\033[0m to the user code."
+
+lint-includes:
+	@clang-tidy $(USER_HEADERS) -checks=-cppcoreguidelines-* --format-style file ||:
+	@echo -e "\033[0;32mNon user-code errors can be ignored.\033[0m They are \033[1;33mnot relevant\033[0m to the user code."
+
+
+
+docs:
+	@doxygen Doxyfile
+
+# Cleans up the bin/ directory, useful when testing compiler flags
+# Watch out for when other files than globals.cpp or main.cpp are changed, as that is unchecked behavior
+clean-bin:
+	@rm bin/*.cpp.* && rm bin/cold* && rm bin/hot*
+	@echo -e "\033[0;32mNow rebuild the program.\033[0m"
+
+	

--- a/common.mk
+++ b/common.mk
@@ -1,9 +1,24 @@
 ARCHTUPLE=arm-none-eabi-
 DEVICE=VEX EDR V5
 
+# User toggles for controlling compiler flags for builds
+# ALWAYS run `make clean-bin` before changing these flags
+DEBUG_LEVEL := 0
+ANALYZE_LEVEL := 0
+
+ifeq ($(DEBUG_LEVEL), 1)	
+	DEBUG_FLAGS += -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow -fsanitize=leak -fsanitize=signed-integer-overflow -fsanitize=bounds -fno-sanitize=null -fno-sanitize=alignment
+endif
+
+ifeq ($(ANALYZE_LEVEL), 1)
+	ANALYZE_FLAGS += -fanalyzer
+endif
+# Optimization flags for the compiler - https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
+OPTIM_FLAGS :=
+
 MFLAGS=-mcpu=cortex-a9 -mfpu=neon-fp16 -mfloat-abi=softfp -Os -g
 CPPFLAGS=-D_POSIX_THREADS -D_UNIX98_THREAD_MUTEX_ATTRIBUTES -D_POSIX_TIMERS -D_POSIX_MONOTONIC_CLOCK
-GCCFLAGS=-ffunction-sections -fdata-sections -fdiagnostics-color -funwind-tables
+GCCFLAGS=-ffunction-sections -fdata-sections -fdiagnostics-color -funwind-tables $(DEBUG_FLAGS) $(ANALYZE_FLAGS) $(OPTIM_FLAGS)
 
 # Check if the llemu files in libvgl exist. If they do, define macros that the
 # llemu headers in the kernel repo can use to conditionally include the libvgl


### PR DESCRIPTION
This PR went slightly over the context of the issue, but it implements the features in the title, but the compiler controls are set to disabled by default as they may cause erratic behavior in production.