### PR TITLE
feat: Add controller robot battery indicator

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,6 +16,5 @@
 Language:        Cpp
 BasedOnStyle:   LLVM
 ColumnLimit:     120
-IndentWidth:     3
-...
-
+AccessModifierOffset: -3
+IndentWidth:     3 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,4 +9,3 @@ CheckOptions:
     value:           '1'
   - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value:           '1'
-...

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -6,7 +6,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+    make:
+        name: Compile Project 
+        runs-on: ubuntu-latest
+
+        steps:
+        - name: checkout
+          uses: actions/checkout@v4
+        
+        - name: Run Centei/pros-build
+          id: build 
+          uses: Centei/pros-build@main
+
+        - name: Upload Artifact
+          uses: actions/upload-artifact@v4
+          with:
+            name: ${{ steps.build.outputs.name }}
+            path: ${{ github.workspace }}/compile_commands.json
+            retention-days: 1
     lint:
+        needs: make
         name: Format and Lint
         runs-on: ubuntu-latest
         permissions:
@@ -16,6 +35,14 @@ jobs:
         steps:
         - name: checkout
           uses: actions/checkout@v4
+
+        - name: Download artifact
+          id: artifact
+          uses: actions/download-artifact@v4
+
+        - name: Move and rename artifact
+          run: |
+            mv ${{ github.workspace }}/artifact/compile_commands.json ../compile_commands.json
         
         - name: Run commitlint
           uses: opensource-nepal/commitlint@7f72e9108526ef0f05afcb1627d1239ed41324c6
@@ -29,7 +56,7 @@ jobs:
             fail_on_error: true
 
         - name: Run linter
-          uses: Centei/cpp-linter-action@python-cache
+          uses: cpp-linter/cpp-linter-action@v2.12.1
           id: linter
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,7 +64,7 @@ jobs:
             style: 'file'
             tidy-checks: 'file'
             tidy-review: true
-            cache: true
+            database: '${{ github.workspace}}'
             version: '18'
 
         - name: Check linter errors
@@ -47,17 +74,3 @@ jobs:
         - name: Check format errors
           if: steps.linter.outputs.clang-format-checks-failed > 0
           run: exit 1
-    make:
-        name: Compile Project 
-        runs-on: ubuntu-latest
-        needs: lint
-
-        steps:
-        - name: checkout
-          uses: actions/checkout@v4
-        
-        - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
-          uses: carlosperate/arm-none-eabi-gcc-action@v1
-
-        - name: make
-          run: make -j4 EXTRA_CXXFLAGS="-O0"

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -42,7 +42,7 @@ jobs:
 
         - name: Move and rename artifact
           run: |
-            mv ${{ github.workspace }}/artifact/compile_commands.json ../compile_commands.json
+            mv ${{ github.workspace }}/compile_commands/compile_commands.json ../compile_commands.json
         
         - name: Run commitlint
           uses: opensource-nepal/commitlint@7f72e9108526ef0f05afcb1627d1239ed41324c6

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ EXCLUDE_COLD_LIBRARIES:=
 # Set this to 1 to add additional rules to compile your project as a PROS library template
 IS_LIBRARY:=0
 # TODO: CHANGE THIS!
-LIBNAME:=libbest
+LIBNAME:=1516X
 VERSION:=1.0.0
 # EXCLUDE_SRC_FROM_LIB= $(SRCDIR)/unpublishedfile.c
 # this line excludes opcontrol.c and similar files

--- a/include/globals.h
+++ b/include/globals.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "api.h"
-#include "lemlib/api.hpp"
-
-// The following files are imported in order to provide type definitions into
-// the compiler that allows for the objecys to
+#include "api.h" // IWYU pragma: export
+#include "lemlib/api.hpp" // IWYU pragma: export
 
 /**
  * @file globals.h

--- a/include/globals.h
+++ b/include/globals.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "api.h" // IWYU pragma: export
+#include "api.h"          // IWYU pragma: export
 #include "lemlib/api.hpp" // IWYU pragma: export
 
 /**
@@ -77,5 +77,5 @@ extern pros::adi::DigitalIn autonToggleSwitch;
 extern pros::adi::Pneumatics LatchControl;
 extern pros::adi::Pneumatics IntakeToggle;
 
-}  // namespace Globals
-}  // namespace Robot
+} // namespace Globals
+} // namespace Robot

--- a/include/main.h
+++ b/include/main.h
@@ -43,6 +43,7 @@
 #include "robot/latch.h"
 #include "screen/selector.h"
 #include "screen/status.h"
+#include "screen/controller.h"
 
 /**
  * You should add more #includes here

--- a/include/main.h
+++ b/include/main.h
@@ -41,9 +41,9 @@
 #include "robot/drivetrain.h"
 #include "robot/intake.h"
 #include "robot/latch.h"
+#include "screen/controller.h"
 #include "screen/selector.h"
 #include "screen/status.h"
-#include "screen/controller.h"
 
 /**
  * You should add more #includes here
@@ -86,4 +86,4 @@ void opcontrol(void);
 // #include <iostream>
 #endif
 
-#endif  // _PROS_MAIN_H_
+#endif // _PROS_MAIN_H_

--- a/include/screen/controller.h
+++ b/include/screen/controller.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace Robot {
+    class Controller {
+        public:
+            void static update_battery_status(void* param);
+    };
+}

--- a/include/screen/controller.h
+++ b/include/screen/controller.h
@@ -1,8 +1,8 @@
 #pragma once
 
 namespace Robot {
-    class Controller {
-        public:
-            void static update_battery_status(void* param);
-    };
-}
+class Controller {
+public:
+   void static update_battery_status(void *param);
+};
+} // namespace Robot

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@ struct RobotSubsystems {
 struct RobotScreen {
   Robot::selector_screen selector;
   Robot::status_screen status;
+  Robot::Controller controller;
 } screen;
 
 /**
@@ -48,6 +49,8 @@ void initialize() {
   chassis.setPose(0, 0, 0);
 
   screen.selector.selector();
+
+  pros::rtos::Task task(screen.controller.update_battery_status);
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ void initialize() {
 
    screen.selector.selector();
 
-   pros::rtos::Task task(screen.controller.update_battery_status);
+   pros::rtos::Task Task(screen.controller.update_battery_status);
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,16 +23,16 @@ using namespace Robot::Globals;
  * @brief Structure that holds instances of all robot subsystems.
  */
 struct RobotSubsystems {
-  Robot::Autonomous autonomous;
-  Robot::Drivetrain drivetrain;
-  Robot::Intake intake;
-  Robot::Latch latch;
+   Robot::Autonomous autonomous;
+   Robot::Drivetrain drivetrain;
+   Robot::Intake intake;
+   Robot::Latch latch;
 } subsystem;
 
 struct RobotScreen {
-  Robot::selector_screen selector;
-  Robot::status_screen status;
-  Robot::Controller controller;
+   Robot::selector_screen selector;
+   Robot::status_screen status;
+   Robot::Controller controller;
 } screen;
 
 /**
@@ -43,14 +43,14 @@ struct RobotScreen {
  */
 
 void initialize() {
-  if (pros::c::registry_get_plugged_type(15) == pros::c::E_DEVICE_IMU) {
-    chassis.calibrate();
-  }
-  chassis.setPose(0, 0, 0);
+   if (pros::c::registry_get_plugged_type(15) == pros::c::E_DEVICE_IMU) {
+      chassis.calibrate();
+   }
+   chassis.setPose(0, 0, 0);
 
-  screen.selector.selector();
+   screen.selector.selector();
 
-  pros::rtos::Task task(screen.controller.update_battery_status);
+   pros::rtos::Task task(screen.controller.update_battery_status);
 }
 
 /**
@@ -83,9 +83,7 @@ void competition_initialize() {}
  * will be stopped. Re-enabling the robot will restart the task, not re-start
  * it from where it left off.
  */
-void autonomous() {
-  subsystem.autonomous.AutoDrive(subsystem.intake, subsystem.latch);
-}
+void autonomous() { subsystem.autonomous.AutoDrive(subsystem.intake, subsystem.latch); }
 
 /**
  * Runs the operator control code. This function will be started in its own
@@ -101,25 +99,25 @@ void autonomous() {
  * the task, not resume it from where it left off.
  */
 void opcontrol() {
-  while (true) {
-    if (controller.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_DOWN)) {
-      autonomous();
-    }
-    if (controller.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_LEFT)) {
-      std::string name = subsystem.drivetrain.toggleDrive();
-      // Output the current drive mode to the controller screen
-      controller.print(0, 0, name.c_str());
-    }
+   while (true) {
+      if (controller.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_DOWN)) {
+         autonomous();
+      }
+      if (controller.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_LEFT)) {
+         std::string name = subsystem.drivetrain.toggleDrive();
+         // Output the current drive mode to the controller screen
+         controller.print(0, 0, name.c_str());
+      }
 
-    subsystem.drivetrain.run();
-    subsystem.latch.run();
+      subsystem.drivetrain.run();
+      subsystem.latch.run();
 
-    // Intake controller, uses the X button holded down to push the elevation
-    // up.
-    subsystem.intake.run();
-    // Intake controller, moves the left and right intakes and stops them if
-    // nothing is pressed.
+      // Intake controller, uses the X button holded down to push the elevation
+      // up.
+      subsystem.intake.run();
+      // Intake controller, moves the left and right intakes and stops them if
+      // nothing is pressed.
 
-    pros::delay(10);  // Small delay to reduce CPU usage
-  }
+      pros::delay(10); // Small delay to reduce CPU usage
+   }
 }

--- a/src/screen/controller.cpp
+++ b/src/screen/controller.cpp
@@ -1,0 +1,30 @@
+#include "main.h" // IWYU pragma: export
+#include "screen/controller.h"
+#include "pros/misc.hpp"
+#include "pros/rtos.h"
+#include <cstdint>
+#include <ctime>
+
+using namespace Robot;
+using namespace Robot::Globals;
+
+void Controller::update_battery_status(void* param) {
+    double capacity = pros::battery::get_capacity();
+    uint32_t now = pros::c::millis();
+    bool hasRumbled = false;
+
+    while (true) {
+        // Should be less than 30% battery capacity
+        if (capacity < 30) {
+            controller.print(0, 0, "B LOW: %d", capacity);
+            if (!hasRumbled) {
+                controller.rumble(". . . . .");
+                bool hasRumbled = true;
+            }
+        }
+        else {
+            controller.print(0, 0, "B: %d", capacity);
+        }
+        pros::c::task_delay_until(&now, 60000);
+    }
+}

--- a/src/screen/controller.cpp
+++ b/src/screen/controller.cpp
@@ -1,5 +1,5 @@
-#include "main.h" // IWYU pragma: export
 #include "screen/controller.h"
+#include "main.h" // IWYU pragma: export
 #include "pros/misc.hpp"
 #include "pros/rtos.h"
 #include <cstdint>
@@ -8,23 +8,23 @@
 using namespace Robot;
 using namespace Robot::Globals;
 
-void Controller::update_battery_status(void* param) {
-    double capacity = pros::battery::get_capacity();
-    uint32_t now = pros::c::millis();
-    bool hasRumbled = false;
+void Controller::update_battery_status(void *param) {
+   double capacity = pros::battery::get_capacity();
+   uint32_t now = pros::c::millis();
+   bool hasRumbled = false;
+   const int LOW_BATTERY = 30;
+   const int MINUTE = 60000;
 
-    while (true) {
-        // Should be less than 30% battery capacity
-        if (capacity < 30) {
-            controller.print(0, 0, "B LOW: %d", capacity);
-            if (!hasRumbled) {
-                controller.rumble(". . . . .");
-                bool hasRumbled = true;
-            }
-        }
-        else {
-            controller.print(0, 0, "B: %d", capacity);
-        }
-        pros::c::task_delay_until(&now, 60000);
-    }
+   while (true) {
+      if (capacity < LOW_BATTERY) {
+         controller.print(0, 0, "B LOW: %d", capacity);
+         if (!hasRumbled) {
+            controller.rumble(". . . . .");
+            bool hasRumbled = true;
+         }
+      } else {
+         controller.print(0, 0, "B: %d", capacity);
+      }
+      pros::c::task_delay_until(&now, MINUTE);
+   }
 }


### PR DESCRIPTION
Closes #25

Uses a PROS task in order to periodically update the indicator on the controller (every minute).
- Prints the current battery to position (0,0) on the VEX controller
- If the battery capacity dips below 30%, the controller will rumble once and the print message will change.